### PR TITLE
feat: variable padding based on # of lines

### DIFF
--- a/registry/blocks/code-block/code-block.css
+++ b/registry/blocks/code-block/code-block.css
@@ -57,7 +57,7 @@ pre,
 .show-line-numbers .shiki .line::before {
   content: counter(step);
   counter-increment: step;
-  margin-right: 1rem;
+  margin-right: var(--line-number-padding, 1rem);
   width: 1rem;
   display: inline-block;
   text-align: right;

--- a/registry/blocks/code-block/code-block.stories.tsx
+++ b/registry/blocks/code-block/code-block.stories.tsx
@@ -305,7 +305,15 @@ console.log(greeting);`,
 };
 
 // Check that the code stays aligned as the # of lines increases
-export const LineNumberWidth: Story = {
+export const HundredLineNumbers: Story = {
+  args: {
+    code: `${"x\n".repeat(101)}`,
+    language: "typescript",
+    showLineNumbers: true,
+  },
+};
+
+export const ThousandLineNumbers: Story = {
   args: {
     code: `${"x\n".repeat(1001)}`,
     language: "typescript",

--- a/registry/blocks/code-block/code-block.tsx
+++ b/registry/blocks/code-block/code-block.tsx
@@ -31,6 +31,11 @@ export function CodeBlock({
   const codeRef = useRef<HTMLDivElement>(null);
   const [isSmallBlock, setIsSmallBlock] = useState<boolean>(false);
 
+  // Calculate dynamic padding for line numbers
+  const lineCount = code.split("\n").length;
+  const extraPadding = 1 + Math.max(0, Math.floor(Math.log10(lineCount))) * 0.2;
+  const lineNumberPadding = `${extraPadding}rem`;
+
   // Base styles for code block container
   const codeBlockBaseStyles =
     "code-block-wrapper border-card relative m-0 mb-2 rounded-md overflow-hidden border p-0 text-xs group";
@@ -68,6 +73,7 @@ export function CodeBlock({
     <div
       ref={codeRef}
       className={cn(codeBlockBaseStyles, `${showLineNumbers && "show-line-numbers"}`, className)}
+      style={{ "--line-number-padding": lineNumberPadding } as React.CSSProperties}
     >
       {/* Buttons - positioned based on block size */}
       <div


### PR DESCRIPTION
Dynamically computes padding based on the # of digits we need to display in line numbers.
Implemented as margin-right on the .line::before so it has no effect if we are nto showing line numbers.
There's a storybook for checking that it still looks good at 100 and 1000 LoC (also tested 10k offline and it looks okay too)

<img width="138" alt="image" src="https://github.com/user-attachments/assets/737c5c02-6e91-4284-aca1-925d749a085a" />
