### PR TITLE
Font modes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,5 +11,6 @@
       "Bash(find:*)"
     ],
     "deny": []
-  }
+  },
+  "enableAllProjectMcpServers": false
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,7 @@ import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
   stories: ["../mirascope-ui/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  staticDirs: ["../public"],
   addons: [
     {
       name: "@storybook/addon-essentials",

--- a/.storybook/modeDecorator.tsx
+++ b/.storybook/modeDecorator.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { ThemeProvider } from "../mirascope-ui/blocks/theme-provider";
+import { FontModeProvider } from "../mirascope-ui/blocks/font-mode-provider";
 import { ModeToggle } from "../mirascope-ui/blocks/mode-toggle";
 import { Toaster } from "sonner";
 export const ModeDecorator = (Story: any) => {
   return (
     <ThemeProvider>
-      <Toaster richColors />
-      <StoryContainer Story={Story} />
+      <FontModeProvider>
+        <Toaster richColors />
+        <StoryContainer Story={Story} />
+      </FontModeProvider>
     </ThemeProvider>
   );
 };

--- a/mirascope-ui/blocks/font-mode-provider.tsx
+++ b/mirascope-ui/blocks/font-mode-provider.tsx
@@ -1,0 +1,66 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+type FontMode = "default" | "fun" | "professional";
+
+type FontModeProviderProps = {
+  children: React.ReactNode;
+  defaultFontMode?: FontMode;
+  storageKey?: string;
+};
+
+type FontModeProviderState = {
+  fontMode: FontMode;
+  setFontMode: (fontMode: FontMode) => void;
+};
+
+const initialState: FontModeProviderState = {
+  fontMode: "default",
+  setFontMode: () => null,
+};
+
+const FontModeProviderContext = createContext<FontModeProviderState>(initialState);
+
+export function FontModeProvider({
+  children,
+  defaultFontMode = "default",
+  storageKey = "mirascope-ui-font-mode",
+  ...props
+}: FontModeProviderProps) {
+  const [fontMode, setFontMode] = useState<FontMode>(
+    () => (localStorage.getItem(storageKey) as FontMode) || defaultFontMode
+  );
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    root.classList.remove("fun-mode", "professional-mode");
+
+    if (fontMode === "default") {
+      // Default mode doesn't need a class
+    } else {
+      root.classList.add(`${fontMode}-mode`);
+    }
+  }, [fontMode]);
+
+  const value = {
+    fontMode,
+    setFontMode: (fontMode: FontMode) => {
+      localStorage.setItem(storageKey, fontMode);
+      setFontMode(fontMode);
+    },
+  };
+
+  return (
+    <FontModeProviderContext.Provider {...props} value={value}>
+      {children}
+    </FontModeProviderContext.Provider>
+  );
+}
+
+export const useFontMode = () => {
+  const context = useContext(FontModeProviderContext);
+
+  if (context === undefined) throw new Error("useFontMode must be used within a FontModeProvider");
+
+  return context;
+};

--- a/mirascope-ui/blocks/mode-toggle.tsx
+++ b/mirascope-ui/blocks/mode-toggle.tsx
@@ -1,16 +1,20 @@
 import { Moon, Sun } from "lucide-react";
 
 import { useTheme } from "@/mirascope-ui/blocks/theme-provider";
+import { useFontMode } from "@/mirascope-ui/blocks/font-mode-provider";
 import { Button } from "@/mirascope-ui/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/mirascope-ui/ui/dropdown-menu";
 
 export const ModeToggle = () => {
   const { setTheme } = useTheme();
+  const { fontMode, setFontMode } = useFontMode();
 
   return (
     <DropdownMenu>
@@ -18,13 +22,36 @@ export const ModeToggle = () => {
         <Button variant="outline" size="icon">
           <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-          <span className="sr-only">Toggle theme</span>
+          <span className="sr-only">Toggle modes</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Color Theme</DropdownMenuLabel>
         <DropdownMenuItem onClick={() => setTheme("light")}>Light</DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("dark")}>Dark</DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>System</DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuLabel>Font Mode</DropdownMenuLabel>
+        <DropdownMenuItem
+          onClick={() => setFontMode("default")}
+          className={fontMode === "default" ? "text-primary" : ""}
+        >
+          Default
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setFontMode("fun")}
+          className={fontMode === "fun" ? "text-primary" : ""}
+        >
+          Fun
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => setFontMode("professional")}
+          className={fontMode === "professional" ? "text-primary" : ""}
+        >
+          Professional
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/mirascope-ui/styles/fonts.css
+++ b/mirascope-ui/styles/fonts.css
@@ -1,0 +1,98 @@
+/**
+ * Sets up the font themes for Mirascope branded UIs
+ *
+ * There are absolute (mode-independent) fonts:
+ *
+ * font-sans: Always renders as a clean sans font (Roboto)
+ * font-handwriting: Always renders as William's Handwriting 
+ * font-handwriting-descent: William's handwriting with descent override
+ * font-mono: Always renders as a monospaced font (Geist Mono)
+ *
+ * We also have three different 'modes' which affect font choices:
+ * default mode (implicit, no class)
+ * .fun-mode (use lots of handwriting)
+ * .professional-mode (use handwriting selectively, only for core branding)
+ *
+ * Thus we have font-default which renders as sans except in fun mode,
+ * and font-fun which renders as handwriting except in professional mode.
+ *
+ * Note font-default can be added for clarity, however it stays in sync with the
+ * default font on the body itself, so setting it is unnecessary.
+ *
+ * In general, font-fun should be used for flavor rather than font-handwriting
+ * (so it may be disabled in professional mode), with font-handwriting
+ * reserved for cases like logo text where it is core to our branding.
+ */
+
+@import url("https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap");
+
+@font-face {
+  font-family: "Williams Handwriting";
+  src: url("/fonts/Williams-Handwriting-Font-v1.9.ttf") format("truetype");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+  descent-override: 10%;
+}
+@font-face {
+  font-family: "Williams Handwriting Descent";
+  src: url("/fonts/Williams-Handwriting-Regular-v1.9.ttf") format("truetype");
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+  descent-override: 10%;
+}
+
+:root {
+  --font-sans:
+    "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
+  --font-mono:
+    "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  --font-handwriting: "Williams Handwriting", cursive;
+  --font-handwriting-descent: "Williams Handwriting Descent", cursive;
+  --font-default: var(--font-sans);
+  --font-fun: var(--font-handwriting);
+}
+
+:is(.professional-mode) {
+  --font-fun: var(--font-sans);
+}
+
+:is(.fun-mode) {
+  --font-default: var(--font-handwriting);
+}
+
+body {
+  font-family: var(--font-default);
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-size: 1rem;
+}
+
+.font-sans {
+  font-family: var(--font-sans) !important;
+}
+
+.font-handwriting {
+  font-family: var(--font-handwriting) !important;
+}
+
+.font-handwriting-descent {
+  font-family: var(--font-handwriting-descent) !important;
+}
+
+.font-mono {
+  font-family: var(--font-mono) !important;
+}
+
+.font-default {
+  font-family: var(--font-default) !important;
+}
+
+.font-fun {
+  font-family: var(--font-fun) !important;
+}

--- a/mirascope-ui/styles/index.css
+++ b/mirascope-ui/styles/index.css
@@ -1,27 +1,12 @@
-/* Google Fonts Import */
-@import url("https://fonts.googleapis.com/css2?family=Baloo+2:wght@400..800&family=Comic+Neue:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Baloo+2:wght@400..800&family=Comic+Neue:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap");
+@import "tailwindcss";
+@import url("@/mirascope-ui/styles/fonts.css");
+@plugin "tailwindcss-animate";
+@plugin '@tailwindcss/typography';
+@custom-variant dark (&:is(.dark *));
 
 /* Import code styling from code-block.css */
 @import url("@/mirascope-ui/blocks/code-block/code-block.css");
 
-/* Williams Handwriting Font Import - All styles */
-@font-face {
-  font-family: "Williams Handwriting";
-  src: url("/fonts/Williams-Handwriting-Font-v1.9.ttf") format("truetype");
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-  descent-override: 10%;
-}
-
-@import "tailwindcss";
-@plugin "tailwindcss-animate";
-@plugin '@tailwindcss/typography';
-@custom-variant dark (&:is(.dark *));
-@custom-variant fun (&:is(.fun *));
-@custom-variant professional (&:is(.professional *));
-@custom-variant default (&:is(.default *));
 @utility no-scrollbar {
   @apply [scrollbar-width:none] [&::-webkit-scrollbar]:hidden;
 }
@@ -160,24 +145,6 @@
 }
 body {
   @apply m-0;
-  font-family:
-    "Williams Handwriting",
-    "Geist Sans",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Open Sans",
-    "Helvetica Neue",
-    sans-serif;
-  font-size: 1rem; /* Default size - will be overridden by mono/sans classes */
-  font-weight: 400; /* Normal weight */
-  letter-spacing: 0.01em; /* Slight letter spacing */
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 /* Paper texture overlay for the entire app */
 body::before {
@@ -213,23 +180,6 @@ body::before {
   }
   body {
     @apply bg-background text-foreground;
-  }
-  .font-default {
-    font-family:
-      "Geist Sans",
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      Roboto,
-      Oxygen,
-      Ubuntu,
-      Cantarell,
-      "Open Sans",
-      "Helvetica Neue",
-      sans-serif;
-  }
-  .font-handwriting {
-    font-family: "Williams Handwriting", cursive !important;
   }
 }
 

--- a/mirascope-ui/ui/button.tsx
+++ b/mirascope-ui/ui/button.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import { cn } from "@/mirascope-ui/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive default:font-fun",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive font-fun",
   {
     variants: {
       variant: {

--- a/mirascope-ui/ui/typography.tsx
+++ b/mirascope-ui/ui/typography.tsx
@@ -5,11 +5,11 @@ import React from "react";
 const typographyVariants = cva("text-xl", {
   variants: {
     variant: {
-      h1: "scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl default:font-fun",
-      h2: "scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0 default:font-fun",
-      h3: "scroll-m-20 text-2xl font-semibold tracking-tight default:font-fun",
-      h4: "scroll-m-20 text-xl font-semibold tracking-tight default:font-fun",
-      h5: "scroll-m-20 text-lg font-semibold tracking-tight default:font-fun",
+      h1: "scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl font-fun",
+      h2: "scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0 font-fun",
+      h3: "scroll-m-20 text-2xl font-semibold tracking-tight font-fun",
+      h4: "scroll-m-20 text-xl font-semibold tracking-tight font-fun",
+      h5: "scroll-m-20 text-lg font-semibold tracking-tight font-fun",
       p: "leading-7 not-first:mt-6",
       span: "",
     },

--- a/registry.json
+++ b/registry.json
@@ -24,7 +24,7 @@
         {
           "path": "mirascope-ui/files/Williams-Handwriting-Font-v1.9.ttf",
           "type": "registry:file",
-          "target": "~/public/fonts/Williams-Handwriting-Font-v1.9.tff"
+          "target": "~/public/fonts/Williams-Handwriting-Font-v1.9.ttf"
         }
       ]
     },


### PR DESCRIPTION
This adds clearer declarative font themeing, according to the rules declared in fonts.css (copied below).

For testing: I updated mode-toggle to allow choosing the font mode, you can swap it and see how the storybook components update fonts accordingly. 

```
/**
 * Sets up the font themes for Mirascope branded UIs
 *
 * There are absolute (mode-independent) fonts:
 *
 * font-sans: Always renders as a clean sans font (Roboto)
 * font-handwriting: Always renders as William's Handwriting 
 * font-handwriting-descent: William's handwriting with descent override
 * font-mono: Always renders as a monospaced font (Geist Mono)
 *
 * We also have three different 'modes' which affect font choices:
 * default mode (implicit, no class)
 * .fun-mode (use lots of handwriting)
 * .professional-mode (use handwriting selectively, only for core branding)
 *
 * Thus we have font-default which renders as sans except in fun mode,
 * and font-fun which renders as handwriting except in professional mode.
 *
 * Note font-default can be added for clarity, however it stays in sync with the
 * default font on the body itself, so setting it is unnecessary.
 *
 * In general, font-fun should be used for flavor rather than font-handwriting
 * (so it may be disabled in professional mode), with font-handwriting
 * reserved for cases like logo text where it is core to our branding.
 */
 ```