### PR TITLE
feat: recursive `add`, simpler `sync`

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(bun test:*)",
       "Bash(bun run test-cli:*)",
       "Bash(rg:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(ls:*)"
     ],
     "deny": []
   },

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ bun add -D @mirascope/ui
 # Initialize your project
 bunx mirascope-ui init
 
-# Add components
+# Add components (automatically syncs if already exists)
 bunx mirascope-ui add button dialog
 
-# Keep components in sync
+# Sync all tracked components
 bunx mirascope-ui sync
 ```
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -8,7 +8,7 @@ import { StatusCommand } from "../src/commands/status";
 import { ExecutionContext } from "../src/commands/base";
 import { FileRegistry, RemoteRegistry } from "../src/registry";
 import { existsSync } from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
 import { REGISTRY_URL } from "@/src/constants";
 
 const COMMANDS = {
@@ -90,6 +90,30 @@ async function main() {
       "Please run this command from your project root or specify a valid --target directory."
     );
     process.exit(1);
+  }
+
+  // Validate --local requires --target
+  if (globalFlags.local && !globalFlags.target) {
+    console.error("❌ --local requires --target to specify where to install components");
+    console.error(
+      "Usage: mirascope-ui --local [--local-path <path>] --target <target-path> <command>"
+    );
+    process.exit(1);
+  }
+
+  // Validate source and target are different directories
+  if (globalFlags.local) {
+    const sourcePath = globalFlags.localPath || process.cwd();
+    const resolvedSource = resolve(sourcePath);
+    const resolvedTarget = resolve(targetPath);
+
+    if (resolvedSource === resolvedTarget) {
+      console.error("❌ Registry source and target directories cannot be the same");
+      console.error(
+        "Use --local-path to specify a different registry location, or --target to specify a different target location."
+      );
+      process.exit(1);
+    }
   }
 
   // Create registry based on flags

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -116,9 +116,9 @@ describe("SyncCommand", () => {
       await command.execute([], context);
 
       expect(logSpy).toHaveBeenCalledWith("🔄 Syncing all 2 tracked components...");
-      expect(logSpy).toHaveBeenCalledWith("🗑️  Removing components: button, card");
-      expect(logSpy).toHaveBeenCalledWith("🔍 Fetching components: button, card");
-      expect(logSpy).toHaveBeenCalledWith("✅ Synced 2 components");
+      expect(logSpy).toHaveBeenCalledWith("🔄 Syncing button...");
+      expect(logSpy).toHaveBeenCalledWith("🔄 Syncing card...");
+      expect(logSpy).toHaveBeenCalledWith("✅ Added 2 components");
 
       const buttonContent = await readFile("mirascope-ui/ui/button.tsx", "utf-8");
       expect(buttonContent).toBe("export const Button = () => <button>Updated Button</button>;");
@@ -165,9 +165,8 @@ describe("SyncCommand", () => {
       await command.execute(["button"], context);
 
       expect(logSpy).toHaveBeenCalledWith("🔄 Syncing components: button");
-      expect(logSpy).toHaveBeenCalledWith("🗑️  Removing components: button");
-      expect(logSpy).toHaveBeenCalledWith("🔍 Fetching components: button");
-      expect(logSpy).toHaveBeenCalledWith("✅ Synced 1 component");
+      expect(logSpy).toHaveBeenCalledWith("🔄 Syncing button...");
+      expect(logSpy).toHaveBeenCalledWith("✅ Added 1 component");
     });
 
     test("shows error for untracked components", async () => {
@@ -192,8 +191,7 @@ describe("SyncCommand", () => {
       await expect(command.execute(["nonexistent"], context)).rejects.toThrow(
         "process.exit called"
       );
-      expect(errorSpy).toHaveBeenNthCalledWith(1, "❌ Components not tracked: nonexistent");
-      expect(errorSpy).toHaveBeenNthCalledWith(2, "Available components:", "button");
+      expect(errorSpy).toHaveBeenCalledWith('❌ Component "nonexistent" not found in registry');
     });
 
     test("updates lastSync timestamp", async () => {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,5 @@
 import { BaseCommand, ExecutionContext } from "./base";
 import { ManifestManager } from "../manifest";
-import { RemoveCommand } from "./remove";
 import { AddCommand } from "./add";
 import { parseArgs } from "util";
 
@@ -55,28 +54,16 @@ export class SyncCommand extends BaseCommand {
 
       let componentsToSync: string[];
       if (componentNames.length > 0) {
-        // Sync specific components
-        const invalidComponents = componentNames.filter(
-          (name) => !(name in manifestData.components)
-        );
-        if (invalidComponents.length > 0) {
-          console.error(`❌ Components not tracked: ${invalidComponents.join(", ")}`);
-          console.error("Available components:", trackedComponents.join(", "));
-          process.exit(1);
-        }
+        // Sync specific components (no need to validate - AddCommand will handle)
         componentsToSync = componentNames;
         console.log(`🔄 Syncing components: ${componentsToSync.join(", ")}`);
       } else {
-        // Sync all components
+        // Sync all tracked components
         componentsToSync = trackedComponents;
         console.log(`🔄 Syncing all ${componentsToSync.length} tracked components...`);
       }
 
-      // Step 1: Remove components
-      const removeCommand = new RemoveCommand();
-      await removeCommand.execute(componentsToSync, context);
-
-      // Step 2: Add components back (which will pull latest + dependencies)
+      // AddCommand now handles remove + add automatically for existing components
       const addCommand = new AddCommand();
       await addCommand.execute(componentsToSync, context);
 
@@ -84,10 +71,6 @@ export class SyncCommand extends BaseCommand {
       if (componentNames.length === 0) {
         await manifest.updateFullSync();
       }
-
-      console.log(
-        `✅ Synced ${componentsToSync.length} component${componentsToSync.length === 1 ? "" : "s"}`
-      );
     } catch (error) {
       console.error(`❌ ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -23,6 +23,12 @@ export async function createTempProject(basePath: string, name: string): Promise
   return projectPath;
 }
 
+export async function createTempRegistry(basePath: string, name: string): Promise<string> {
+  const registryPath = join(basePath, name);
+  await mkdir(registryPath, { recursive: true });
+  return registryPath;
+}
+
 export async function cleanupTempDir(path: string): Promise<void> {
   try {
     await rm(path, { recursive: true, force: true });


### PR DESCRIPTION
Current add command has a bug in that it doesn't operate recursively - so if A depends on B, and B depends on C, then add will install B but not C

This PR re-implements add so that it operates recursively. Also, it now does the better behavior of doing a full sync under the hood - i.e. removing the component and then re-adding it. It does _this_ recursively, which means if A depends on B, and B depends on C, and you have an older version of C installed, it will re-install C, thus ensuring that B has the latest version of the dependency. Of course, this may affect other other components — and there is an edge case where you could have some other dependency X, also depending on C, which should be re-installed in case it needed any compatibility changes for the latest version of X.

For that reason, it's still best to use `mirascope-ui sync` when adding components so that everything gets re-installed. Now that add handles removing and re-adding deps, `sync` is basically a sugar for "re add everything".

Under the hood, `add` keeps track of which components have already been removed and re-added, so there is no potential exponential blowup with common dependencies getting repeatedly removed and re-installed.

Docs and tests updated to reflect this change. There is now also a sanity check that the command will not install components into the registry repo itself — which has no possible benefit, and the possible downside of removing components from the source repository, which is undesirable. 