### PR TITLE
Remove `dark:` style overrides from base button

### DIFF
--- a/mirascope-ui/ui/button.tsx
+++ b/mirascope-ui/ui/button.tsx
@@ -20,7 +20,8 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 ",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 ",
-        outline: "border bg-background shadow-xs hover:bg-muted hover:cursor-pointer ",
+        outline:
+          "border border-primary text-primary bg-background shadow-xs hover:bg-accent hover:text-accent-foreground hover:cursor-pointer",
         outlineDestructive:
           "border border-input bg-background text-destructive hover:cursor-pointer hover:bg-destructive-hover",
         outlineSecondary:
@@ -53,12 +54,12 @@ const buttonVariants = cva(
   }
 );
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-  loading?: boolean;
-}
+export type ButtonProps = React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+    loading?: boolean;
+  };
+
 function Button({
   className,
   loading = false,


### PR DESCRIPTION
This PR removes the `dark:` style overrides from base button.

The way I am using the UI system, there is generally not a need for `dark:` overrides, because the color variables themselves update in dark mode. For example, in `dark`, the accent color shifts to better harmonize with a dark background.

Specifying `dark:` classes on the base button disrupts this usage, since the `dark:` marker gets additional specificity and may interfere with overrides that are being applied, basically forcing the "special case dark mode" logic to bubble up to components that inherit it.

As a specific case, consider the `TabsTrigger`, which inherits button styling:

```ts
function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
  return (
    <TabsPrimitive.Trigger
      data-slot="tabs-trigger"
      className={cn(
        buttonVariants({
          variant: "ghost",
          size: "sm",
        }),
        "data-[state=active]:bg-primary data-[state=active]:text-primary-foreground cursor-pointer",
        className
      )}
      {...props}
    />
  );
}
```

In light mode, the `data-[state=active]:bg-primary` overrides the `hover:` from button, which is desirable — we don't the active tab to become *less* intense when hovered. However, in the current implementation, the `dark:hover:bg-accent/50` is more specific and overrides it, which means that tabs would need to have `dark:data-[state=active]:bg-primary` too, and so forth. 

Hence, while it's still fine for downstream users to set custom `dark:` overrides if desired, I don't want to do so in the base ui components.

To see this in action, try hovering over the active tab in dark mode on the tab storybook (https://ui.mirascope.com/?path=/story/ui-tabs--default) and compare with the better behavior from this PR.